### PR TITLE
Move TOCs below first heading

### DIFF
--- a/DBS/README.md
+++ b/DBS/README.md
@@ -1,3 +1,6 @@
+Datenbanken
+===========
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Inhaltsverzeichnis**
@@ -22,9 +25,6 @@
     - [Operationen](#operationen)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-Datenbanken
-===========
 
 # Grundlagen
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# DHGE - Praktische Informatik - Matrikel 19 - Semester 3
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Inhaltsverzeichnis**
@@ -10,8 +12,6 @@
   - [SWE - Systementwicklung](#swe---systementwicklung)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# DHGE - Praktische Informatik - Matrikel 19 - Semester 3
 
 ## DBS - Datenbanken
 

--- a/RES/README.md
+++ b/RES/README.md
@@ -1,3 +1,6 @@
+Betriebssystemverwaltung
+========================
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Inhaltsverzeichnis**
@@ -10,9 +13,6 @@
   - [VMs mit Snapshots vor Schäden schützen](#vms-mit-snapshots-vor-sch%C3%A4den-sch%C3%BCtzen)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-Betriebssystemverwaltung
-========================
 
 <!---
 created by Maximilian Kerst, 05.10.2020


### PR DESCRIPTION
Die TOCs sollten unter der ersten Überschrift sein. 