### PR TITLE
README: Markdown-Erweiterungen, small Contribution Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Alle Skripte in diesem Repository sind im `markdown`-Format verfasst. Für diese
 <!--newpage-->
 <!--clearpage-->
 ```
+
+### Mathematische Formel
+
+Github unterstützt keine mathematischen Formeln. Als Workaround gibt es eine [Erweiterung für Chrome](https://github.com/orsharir/github-mathjax). Ansonsten können Formeln in ihrer vollen Pracht nur in den PDFs betrachtet werden.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,22 @@ Alle Kommilitonen sind dazu eingeladen, ihre eigenen Beiträge zu diesem Projekt
 3. `git clone` deine Fork und erstelle mit `git checkout -b <branchname>` eine neue Branch
 4. Implementiere deine Idee. Bei Fragen kannst du dich gerne über das Issue an uns wenden.
 5. Erstelle eine Pull Request, markiere dabei die Personen aus dem Issue und warte auf Feedback.
+
+## Markdown-Erweiterungen
+
+Alle Skripte in diesem Repository sind im `markdown`-Format verfasst. Für dieses existieren [viele verschiedene Standards](https://de.wikipedia.org/wiki/Markdown#Weiterentwicklungen,_Variationen_und_Erg%C3%A4nzungen). Auf Github selbst ist der Funktionsumfang von `markdown` im Vergleich zu anderen Standards deutlich eingeschränkt. Es ist beispielsweise nicht möglich die Größe von Bilder zu definieren, Metadaten für Dokumente anzugeben oder Mathematische Formel darzustellen. Aus diesem Grund wird [`pandoc`](https://pandoc.org/) verwendet, um `markdown`-Dateien mit vielen Funktionserweiterungen in PDFs umzuwandeln. Damit eine Kompatibilität zum Github-`markdown` haben wir eigene Erweiterungen definiert die im Folgenden beschrieben werden:
+
+### Bildgröße
+
+```md
+![Bildbeschreibung](img/a.png)<!--width=200px-->
+![Bildbeschreibung](img/b.png)<!--height=200px-->
+```
+
+### Pagebreaks usw.
+
+```md
+<!--pagebreak-->
+<!--newpage-->
+<!--clearpage-->
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DHGE - Praktische Informatik - Matrikel 19 - Semester 3
 
-Dieses Repository ist ein Projekt von Studierenden des Studiengangs "Praktische Informatik" der Dualen Hochschule Gera-Eisenach. Hier werden alle Mitschriften der einzelnen Modulen gesammelt. Die Skripte liegen im `markdown`-Format vor. Zur besseren Handhabung (und weil Github nur begrenzte `markdown`-Features bereitstellt) werden diese zusätzlich automatisch in [PDFs](https://github.com/importPI19fromDHGE/dhge-pi19-sem3/releases) umgewandelt und zur Verfügung gestellt. Alle Kommilitonen sind dazu eingeladen, ihre eigenen Beiträge zu diesem Projekt zu leisten und ihre Ideen einzubringen.
+Dieses Repository ist ein Projekt von Studierenden des Studiengangs "Praktische Informatik" der Dualen Hochschule Gera-Eisenach. Hier werden alle Mitschriften der einzelnen Modulen gesammelt. Die Skripte liegen im `markdown`-Format vor. Zur besseren Handhabung (und weil Github nur begrenzte `markdown`-Features bereitstellt) werden diese zusätzlich automatisch in [PDFs](https://github.com/importPI19fromDHGE/dhge-pi19-sem3/releases) umgewandelt und zur Verfügung gestellt.
 
 ## Module
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ Dieses Repository ist ein Projekt von Studierenden des Studiengangs "Praktische 
 - [PRO - IT-Trends](./PRO)
 - [SWE - Systemanalyse](./SWE)
 - [NET - Rechnernetze](./NET)
+
+## Contributing
+
+Alle Kommilitonen sind dazu eingeladen, ihre eigenen Beiträge zu diesem Projekt zu leisten und ihre Ideen einzubringen. Wenn du einen Beitrag leisten willst, kannst du wie folgt vorgehen:
+
+1. Wenn du hier Neu bist, erstelle auf jeden Fall ersteinmal [ein Issue](./issues). Dann können wir uns gerne über deine Idee austauschen.
+2. Forke dieses Repository
+3. `git clone` deine Fork und erstelle mit `git checkout -b <branchname>` eine neue Branch
+4. Implementiere deine Idee. Bei Fragen kannst du dich gerne über das Issue an uns wenden.
+5. Erstelle eine Pull Request, markiere dabei die Personen aus dem Issue und warte auf Feedback.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Dieses Repository ist ein Projekt von Studierenden des Studiengangs "Praktische Informatik" der Dualen Hochschule Gera-Eisenach. Hier werden alle Mitschriften der einzelnen Modulen gesammelt. Die Skripte liegen im `markdown`-Format vor. Zur besseren Handhabung (und weil Github nur begrenzte `markdown`-Features bereitstellt) werden diese zusätzlich automatisch in [PDFs](https://github.com/importPI19fromDHGE/dhge-pi19-sem3/releases) umgewandelt und zur Verfügung gestellt.
 
+## Contributing
+
+Alle Kommilitonen sind dazu eingeladen, ihre eigenen Beiträge zu diesem Projekt zu leisten und ihre Ideen einzubringen. Wenn du einen Beitrag leisten willst, kannst du wie folgt vorgehen:
+
+1. Wenn du hier neu bist, erstelle auf jeden Fall ersteinmal [ein Issue](./issues). Dann können wir uns gerne über deine Idee austauschen.
+2. Forke dieses Repository
+3. `git clone <fork>` deine Fork und erstelle mit `git checkout -b <branchname>` eine neue Branch
+4. Implementiere deine Idee. Bei Fragen kannst du dich gerne über das Issue an uns wenden.
+5. Erstelle eine Pull Request, markiere dabei die Personen aus dem Issue und warte auf Feedback.
+
 ## Module
 
 - [DBS - Datenbanken](./DBS)
@@ -9,16 +19,6 @@ Dieses Repository ist ein Projekt von Studierenden des Studiengangs "Praktische 
 - [PRO - IT-Trends](./PRO)
 - [SWE - Systemanalyse](./SWE)
 - [NET - Rechnernetze](./NET)
-
-## Contributing
-
-Alle Kommilitonen sind dazu eingeladen, ihre eigenen Beiträge zu diesem Projekt zu leisten und ihre Ideen einzubringen. Wenn du einen Beitrag leisten willst, kannst du wie folgt vorgehen:
-
-1. Wenn du hier Neu bist, erstelle auf jeden Fall ersteinmal [ein Issue](./issues). Dann können wir uns gerne über deine Idee austauschen.
-2. Forke dieses Repository
-3. `git clone` deine Fork und erstelle mit `git checkout -b <branchname>` eine neue Branch
-4. Implementiere deine Idee. Bei Fragen kannst du dich gerne über das Issue an uns wenden.
-5. Erstelle eine Pull Request, markiere dabei die Personen aus dem Issue und warte auf Feedback.
 
 ## Markdown-Erweiterungen
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Alle Kommilitonen sind dazu eingeladen, ihre eigenen Beiträge zu diesem Projekt
 
 ## Markdown-Erweiterungen
 
-Alle Skripte in diesem Repository sind im `markdown`-Format verfasst. Für dieses existieren [viele verschiedene Standards](https://de.wikipedia.org/wiki/Markdown#Weiterentwicklungen,_Variationen_und_Erg%C3%A4nzungen). Auf Github selbst ist der Funktionsumfang von `markdown` im Vergleich zu anderen Standards deutlich eingeschränkt. Es ist beispielsweise nicht möglich die Größe von Bilder zu definieren, Metadaten für Dokumente anzugeben oder Mathematische Formel darzustellen. Aus diesem Grund wird [`pandoc`](https://pandoc.org/) verwendet, um `markdown`-Dateien mit vielen Funktionserweiterungen in PDFs umzuwandeln. Damit eine Kompatibilität zum Github-`markdown` haben wir eigene Erweiterungen definiert die im Folgenden beschrieben werden:
+Alle Skripte in diesem Repository sind im `markdown`-Format verfasst. Für dieses existieren [viele verschiedene Standards](https://de.wikipedia.org/wiki/Markdown#Weiterentwicklungen,_Variationen_und_Erg%C3%A4nzungen). Auf Github selbst ist der Funktionsumfang von `markdown` im Vergleich zu anderen Standards deutlich eingeschränkt. Es ist beispielsweise nicht möglich die Größe von Bilder zu definieren, Metadaten für Dokumente anzugeben oder Mathematische Formel darzustellen. Aus diesem Grund wird [`pandoc`](https://pandoc.org/) verwendet, um `markdown`-Dateien mit vielen Funktionserweiterungen in PDFs umzuwandeln. Damit eine Kompatibilität zum Github-`markdown` haben wir eigene Erweiterungen definiert, die im Folgenden beschrieben werden:
 
 ### Bildgröße
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Alle Kommilitonen sind dazu eingeladen, ihre eigenen Beiträge zu diesem Projekt
 2. Forke dieses Repository
 3. `git clone <fork>` deine Fork und erstelle mit `git checkout -b <branchname>` eine neue Branch
 4. Implementiere deine Idee. Bei Fragen kannst du dich gerne über das Issue an uns wenden.
-5. Erstelle eine Pull Request, markiere dabei die Personen aus dem Issue und warte auf Feedback.
+5. Erstelle eine Pull Request, markiere dabei via @mention die Personen aus dem Issue und warte auf Feedback.
 
 ## Module
 


### PR DESCRIPTION
Wie in #72 beschrieben, hier mein Vorschlag für die Dokumentation der Markdown-Erweiterungen. Gleichzeitig habe ich noch einen kurzen Contribution-Guide hinzugefügt. Das Ganze ist nur ein Vorschlag für Änderungen oder weitere Vorschläge bin ich gerne offen.

resolves #72